### PR TITLE
fix: 農曆顯示使用農曆年而非公曆年 (#14) / use lunar year in 農曆 display

### DIFF
--- a/src/ichingshifa/ichingshifa.py
+++ b/src/ichingshifa/ichingshifa.py
@@ -781,7 +781,7 @@ class Iching():
         except (ValueError,IndexError):
             father_luck = ""
         a = "起卦時間︰{}年{}月{}日{}時{}分\n".format(year, month, day, hour, minute)
-        b = "農曆︰{}{}月{}日\n".format(cn2an.transform(str(year)+"年", "an2cn"), an2cn(self.lunar_date_d(year, month, day).get("月")), an2cn(self.lunar_date_d(year,month, day).get("日")))
+        b = "農曆︰{}{}月{}日\n".format(cn2an.transform(str(self.lunar_date_d(year, month, day).get("年"))+"年", "an2cn"), an2cn(self.lunar_date_d(year, month, day).get("月")), an2cn(self.lunar_date_d(year,month, day).get("日")))
         c = "干支︰{}年  {}月  {}日  {}時\n".format(gz[0], gz[1], gz[2], gz[3])
         j_q = jq(year, month, day, hour, minute)
         c0 = "節氣︰{} | 旺︰{} | 相︰{}\n".format(j_q, gong_wangzhuai(j_q)[1].get("旺"), gong_wangzhuai(j_q)[1].get("相"))
@@ -1013,7 +1013,7 @@ class Iching():
         except (ValueError,IndexError):
             father_luck = ""
         a = "起卦時間︰{}年{}月{}日{}時{}分\n".format(year, month, day, hour, minute)
-        b = "農曆︰{}{}月{}日\n".format(cn2an.transform(str(year)+"年", "an2cn"), an2cn(self.lunar_date_d(year, month, day).get("月")), an2cn(self.lunar_date_d(year,month, day).get("日")))
+        b = "農曆︰{}{}月{}日\n".format(cn2an.transform(str(self.lunar_date_d(year, month, day).get("年"))+"年", "an2cn"), an2cn(self.lunar_date_d(year, month, day).get("月")), an2cn(self.lunar_date_d(year,month, day).get("日")))
         c = "干支︰{}年  {}月  {}日  {}時\n".format(gz[0], gz[1], gz[2], gz[3])
         j_q = jq(year, month, day, hour, minute)
         c0 = "節氣︰{} | 旺︰{} | 相︰{}\n".format(j_q, gong_wangzhuai(j_q)[1].get("旺"), gong_wangzhuai(j_q)[1].get("相"))


### PR DESCRIPTION
## 中文

修正 issue #14。

`display_pan` 與 `display_pan_m` 兩個方法在組合「農曆」一行時，月與日是從 `lunar_date_d()` 取得的，但**年**卻直接沿用傳入的公曆 `year`。對於農曆新年之前（公曆年初）的日期，這會顯示錯誤的農曆年。

例如 **2026-01-15**，正確農曆為 `二零二五年十一月二十七日`，修正前卻顯示為 `二零二六年…`。

修正方式：年份同樣改從 `lunar_date_d(year, month, day).get("年")` 取得，與月、日一致。issue #14 回報者已先提出單處的修正建議；本 PR 在 `display_pan` 與 `display_pan_m` **兩處**都一併修正。

### 驗證

| 日期 | 農曆年 | 修正前 | 修正後 |
|------|--------|--------|--------|
| 2026-01-15 | 2025 | `農曆︰二零二六年十一月二十七日` ❌ | `農曆︰二零二五年十一月二十七日` ✅ |
| 2025-06-15 | 2025 | `農曆︰二零二五年五月二十日` | `農曆︰二零二五年五月二十日`（不變 ✅） |

公曆年中（公曆年＝農曆年）的日期輸出不變，無回歸問題。

> ⚠️ 說明：本 PR 的中文說明由 AI 協助撰寫，用詞或語氣可能不完全符合慣例，還請見諒。我本身只說英文，但很欣賞並重視這個結合道家文化與技術的專案，因此希望能貢獻一份心力。

---

## English

Fixes #14.

In `display_pan` and `display_pan_m`, the 農曆 (lunar date) line takes the **month** and **day** from `lunar_date_d()` but kept the raw Gregorian `year`. For dates before Lunar New Year (early in the Gregorian year) this shows the wrong lunar year.

Example **2026-01-15**: the correct lunar date is `二零二五年十一月二十七日`, but it previously rendered `二零二六年…`.

Fix: take the year from `lunar_date_d(year, month, day).get("年")`, consistent with the month and day. The #14 reporter drafted a fix for one site; this PR fixes **both** occurrences (`display_pan` and `display_pan_m`).

### Verification

| Date | Lunar year | Before | After |
|------|-----------|--------|-------|
| 2026-01-15 | 2025 | `農曆︰二零二六年十一月二十七日` ❌ | `農曆︰二零二五年十一月二十七日` ✅ |
| 2025-06-15 | 2025 | `農曆︰二零二五年五月二十日` | `農曆︰二零二五年五月二十日` (unchanged ✅) |

Mid-Gregorian-year dates (where Gregorian year == lunar year) are unchanged — no regression.

> ⚠️ Note: the Chinese text in this PR was AI-generated and may not be 100% accurate or match the usual tone and cultural conventions. I'm an English-only speaker, but I value this kind of work bridging Taoist culture and technology, which is why I'm contributing.
