### PR TITLE
fix: 伏神缺兩個六親時為空的問題 (#11) / populate 伏神 when two relatives are missing

### DIFF
--- a/src/ichingshifa/ichingshifa.py
+++ b/src/ichingshifa/ichingshifa.py
@@ -498,21 +498,22 @@ class Iching():
         accumulate_code = dict(zip(self.data.get("六十四卦"),self.data.get("積算"))).get(gua_name)
         accumulate = self.new_list(self.jiazi(), accumulate_code)
         aa = list(set(lq))
-        fu =  str(str([value for value in liuqin if value not in aa]).replace("['","").replace("']",""))
+        missing_liuqin = [value for value in liuqin if value not in aa]
         fu_gua = self.dc_gua(self.multi_key_dict_get(self.bagua_pure_code, gua_name))
         fu_gua_gang = fu_gua.get("天干")
         fu_gua_zhi = fu_gua.get("地支")
         fu_gua_wu = fu_gua.get("五行")
         fu_gua_lq = fu_gua.get("六親用神")
         shen = self.multi_key_dict_get(self.shen, d[Shiying.index("世")])
-        try:
-            fu_num = fu_gua_lq.index(fu)
-            fuyao = [str(g ==fu) for g in fu_gua_lq].index('True')
+        fu_yao_list = []
+        for fu in missing_liuqin:
+            try:
+                fu_num = fu_gua_lq.index(fu)
+            except (ValueError, IndexError, AttributeError):
+                continue
             fuyao1 = fu_gua_lq[fu_num] + fu_gua_gang[fu_num] +  fu_gua_zhi[fu_num] + fu_gua_wu[fu_num]
-            fu_yao = {"伏神所在爻": lq[fuyao], "伏神六親":fu, "伏神排爻數字":fu_num, "本卦伏神所在爻":lq[fu_num]+t[fu_num]+d[fu_num]+w[fu_num], "伏神爻":fuyao1}
-
-        except (ValueError, IndexError ,AttributeError):
-            fu_yao = ""
+            fu_yao_list.append({"伏神所在爻": lq[fu_num], "伏神六親":fu, "伏神排爻數字":fu_num, "本卦伏神所在爻":lq[fu_num]+t[fu_num]+d[fu_num]+w[fu_num], "伏神爻":fuyao1})
+        fu_yao = fu_yao_list[0] if fu_yao_list else ""
         
         return {"卦":gua_name, 
                 "五星":ss, 
@@ -523,8 +524,9 @@ class Iching():
                 "五行":w, 
                 "世應爻":Shiying, 
                 "身爻":lq[shen]+t[shen]+d[shen]+w[shen],
-                "六親用神":lq, 
+                "六親用神":lq,
                 "伏神":fu_yao,
+                "伏神列表":fu_yao_list,
                 "六獸":self.find_six_mons(daygangzhi),
                 "納甲":ng, 
                 "建月":build_month, 


### PR DESCRIPTION
## 中文

修正 issue #11。

`decode_gua` 在計算伏神時，用 `str([缺失的六親]).replace("['","").replace("']","")` 把「缺失的六親」清單壓成一個字串。當卦只缺**一個**六親時沒問題；但當缺**兩個**時（例如 **渙卦 878877** 同時缺 官鬼 與 妻財），這個字串會變成不合法的 `"官', '妻"`，導致 `fu_gua_lq.index(fu)` 拋出 `ValueError`，被 `except` 吞掉後 **伏神變成空字串**。

### 修正方式

改為**逐一**處理每個缺失的六親，分別到本宮首卦中尋找其伏神：
- `伏神` 仍維持原本的單一字典結構（取第一個伏神），**完全向後相容**；
- 新增 `伏神列表` 鍵，列出所有伏神。

### 驗證（全 64 卦）

逐卦比對修正前後：**所有原本非空的「伏神」結果完全不變**；只有原本因此 bug 而為空的卦被正確補上。

- 缺一個六親：32 卦（行為不變）
- 缺兩個六親：**12 卦**（修正前皆為空，現已補上）

以 **渙卦（878877，離宮五世卦）** 為例：

| | 修正前 | 修正後 |
|---|---|---|
| 伏神 | `''`（空）❌ | `官己亥水` ✅ |
| 伏神列表 | — | `官己亥水`、`妻己酉金`（取自離宮首卦）✅ |

`decode_two_gua`、`display_pan` 等下游函式不受影響（伏神結構不變）。

> 💡 後續可考慮在排盤圖（`display_pan`）中同時顯示兩個伏神；本 PR 先修正資料層的空值問題，並保留完整資料於 `伏神列表`。

> ⚠️ 說明：本 PR 的中文說明由 AI 協助撰寫，用詞或語氣可能不完全符合慣例，還請見諒。我本身只說英文，但很欣賞並重視這個結合道家文化與技術的專案，因此希望能貢獻一份心力。

---

## English

Fixes #11.

When computing 伏神 (hidden spirits), `decode_gua` flattened the list of missing 六親 (Five Relatives) into a single string with `str([...]).replace("['","").replace("']","")`. This works when a hexagram is missing **one** relative, but when it's missing **two** (e.g. **渙 878877** is missing both 官鬼 and 妻財) the string becomes the malformed `"官', '妻"`. `fu_gua_lq.index(fu)` then raises `ValueError`, the bare `except` swallows it, and **伏神 is left empty**.

### Fix

Iterate over each missing relative and look each up in the palace head hexagram (本宮首卦):
- `伏神` keeps its original single-dict shape (the first hidden spirit) — **fully backward compatible**.
- A new `伏神列表` key exposes the complete set of hidden spirits.

### Verification (all 64 hexagrams)

Compared before/after for every hexagram: **every previously non-empty 伏神 is byte-for-byte unchanged**; only hexagrams that were wrongly empty due to this bug are now populated.

- Missing one relative: 32 hexagrams (unchanged)
- Missing two relatives: **12 hexagrams** (were empty, now populated)

Example — **渙 (878877), the 5th-generation hexagram of the 離 palace:**

| | Before | After |
|---|---|---|
| 伏神 | `''` (empty) ❌ | `官己亥水` ✅ |
| 伏神列表 | — | `官己亥水`, `妻己酉金` (from 離宮首卦) ✅ |

Downstream functions (`decode_two_gua`, `display_pan`) are unaffected since 伏神's shape is preserved.

> 💡 A possible follow-up is rendering both hidden spirits in the `display_pan` board; this PR fixes the data-layer empty-value bug and keeps the full set in 伏神列表.

> ⚠️ Note: the Chinese text in this PR was AI-generated and may not be 100% accurate or match the usual tone and cultural conventions. I'm an English-only speaker, but I value this kind of work bridging Taoist culture and technology, which is why I'm contributing.
